### PR TITLE
Issue #1. Android 7.1 issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bin
 gen
+*.iml
+.idea

--- a/src/name/boyle/chris/keytest/KeyTest.java
+++ b/src/name/boyle/chris/keytest/KeyTest.java
@@ -17,9 +17,12 @@ public class KeyTest extends Activity {
 	TextView text;
 
 	@Override
-	public boolean onKeyDown(int keycode, KeyEvent event)
-	{
-		text.setText("Keycode: "+keycode+"\nKeyEvent: "+event.toString());
-		return true;
+	public boolean dispatchKeyEvent(final KeyEvent event) {
+		if (KeyEvent.ACTION_DOWN == event.getAction()) {
+			text.setText(
+				"Keycode: " + event.getKeyCode() + "\nKeyEvent: " + event.toString()
+			);
+		}
+		return super.dispatchKeyEvent(event);
 	}
 }


### PR DESCRIPTION
Recently I had similar problem to what is described in #1. I have Android TV device with Android 7.1.2 and remote control which I need to re-map properly, so I need to know all the keys. After some googling I found out this answer on stackoverflow: https://stackoverflow.com/a/41646524/1842599 I've tested it: I still can not catch 100% of the keys on my remote control, but with `dispatchKeyEvent()` I'm catching definitely much more than with `onKeyDown()`

The changes of this PR:
- KeyTest: `onKeyDown()` replaced with `dispatchKeyEvent()` as it catches more key events;
- .gitignore was adjusted for IntelliJ.

@chrisboyle what do you think about these changes? Are they acceptable?